### PR TITLE
Add example web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ The `BBoxAnnotator` Component takes the following props in order to control it's
  * `borderWidth?: number`: Width of bounding box border in pixels.
  * `initialEntries?: { left: number; top: number; width: number; height: number; label: string }[]`: Load existing annotations so they can be edited.
 
-Boxes can be repositioned after creation by dragging them with the mouse.
+Boxes can be repositioned after creation by dragging them with the mouse.\n## Local examples\nRun `npm run examples` and open the served page to try interactive examples located in the `examples` folder.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Examples
+
+This folder contains basic usage examples for **react-bbox-annotator**.
+
+Run the following command from the repository root to start a development server:
+
+```bash
+npm run examples
+```
+
+This will launch a Vite web server and open a page showing two examples:
+
+1. A selector based example where labels are chosen from a list.
+2. A text input based example for free form labels.
+
+The code for these examples is located in `main.tsx`.

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BBox Annotator Examples</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import BBoxAnnotator, { EntryType } from 'react-bbox-annotator';
+
+const ExampleSelect: React.FC = () => {
+  const labels = ['Dog', 'Cat', 'Bird'];
+  const [entries, setEntries] = React.useState<EntryType[]>([]);
+  return (
+    <div style={{ width: '60%', marginBottom: 20 }}>
+      <h3>Select labels</h3>
+      <BBoxAnnotator
+        url="https://images.unsplash.com/photo-1517423440428-a5a00ad493e8?auto=format&fit=crop&w=800&q=80"
+        inputMethod="select"
+        labels={labels}
+        onChange={setEntries}
+      />
+      <pre>{JSON.stringify(entries, null, 2)}</pre>
+    </div>
+  );
+};
+
+const ExampleText: React.FC = () => {
+  const [entries, setEntries] = React.useState<EntryType[]>([]);
+  return (
+    <div style={{ width: '60%', marginBottom: 20 }}>
+      <h3>Text labels</h3>
+      <BBoxAnnotator
+        url="https://images.unsplash.com/photo-1601758003122-74ee9c837035?auto=format&fit=crop&w=800&q=80"
+        inputMethod="text"
+        onChange={setEntries}
+      />
+      <pre>{JSON.stringify(entries, null, 2)}</pre>
+    </div>
+  );
+};
+
+const App: React.FC = () => (
+  <>
+    <ExampleSelect />
+    <ExampleText />
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [react()],
+  resolve: {
+    alias: {
+      'react-bbox-annotator': path.resolve(__dirname, '../src'),
+    },
+  },
+  server: {
+    open: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "lint:eslint:fix": "./node_modules/.bin/eslint --ignore-path .gitignore --fix",
     "lint:js": "npm run lint:eslint -- . ",
     "lint:staged": "lint-staged",
-    "prettify": "prettier --write"
+    "prettify": "prettier --write",
+    "examples": "vite --config examples/vite.config.ts"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [


### PR DESCRIPTION
## Summary
- create `examples` folder with Vite config, example React code and docs
- expose `npm run examples` to start the example server
- mention examples in README

## Testing
- `npm run build`
- `npx vite build --config examples/vite.config.ts`
- `npm run lint` *(fails: Parsing error from @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_e_6876cef3663c8325ad71e4b31a6993ab