### PR TITLE
Fix bbox editing during label entry

### DIFF
--- a/src/BBoxAnnotator/index.tsx
+++ b/src/BBoxAnnotator/index.tsx
@@ -359,11 +359,13 @@ const BBoxAnnotator = React.forwardRef<any, Props>(
                             }}
                             key={entry.id}
                             onMouseDown={(e) => {
-                                if (e.button !== 2 && status === 'free') {
+                                if (e.button !== 2 && (status === 'free' || status === 'input')) {
                                     e.stopPropagation();
                                     const pos = crop(e.pageX, e.pageY);
                                     setDraggingId(entry.id);
                                     setDragOffset({ x: pos.x - entry.left, y: pos.y - entry.top });
+                                    setPointer(null);
+                                    setOffset(null);
                                     setStatus('drag');
                                 }
                             }}


### PR DESCRIPTION
## Summary
- allow dragging a bbox even if label input is visible

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877ddfc19ac83258079420d350ef2cf