### PR TITLE
Add defaultValue for LabelBox

### DIFF
--- a/src/BBoxAnnotator/index.tsx
+++ b/src/BBoxAnnotator/index.tsx
@@ -542,6 +542,7 @@ const BBoxAnnotator = React.forwardRef<any, Props>(
                                     top={entry.height + borderWidth}
                                     left={-borderWidth}
                                     labels={labels}
+                                    defaultValue={entry.label}
                                     onSubmit={submitLabel}
                                     ref={labelInputRef}
                                 />

--- a/src/LabelBox/index.tsx
+++ b/src/LabelBox/index.tsx
@@ -16,10 +16,11 @@ interface Props {
     inputMethod: 'text' | 'select';
     labels?: string | string[];
     onSubmit: (label: string) => void;
+    defaultValue?: string;
 }
-const LabelBox = React.forwardRef<any, Props>(({ inputMethod, ...props }, forwardedRef) => {
+const LabelBox = React.forwardRef<any, Props>(({ inputMethod, defaultValue = '', ...props }, forwardedRef) => {
     const classes = useStyles(props);
-    const [value, setValue] = useState('');
+    const [value, setValue] = useState(defaultValue);
     const changeHandler = (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLSelectElement>) => {
         setValue(e.target.value);
         if (inputMethod === 'select') {
@@ -47,8 +48,9 @@ const LabelBox = React.forwardRef<any, Props>(({ inputMethod, ...props }, forwar
                     ref={forwardedRef}
                     onChange={changeHandler}
                     onMouseDown={(e) => e.stopPropagation()}
+                    value={value}
                 >
-                    <option>choose an item</option>
+                    <option value="">choose an item</option>
                     {labels.map((label) => (
                         <option key={label} value={label}>
                             {label}


### PR DESCRIPTION
## Summary
- allow providing a defaultValue to `LabelBox`
- pass the entry label as defaultValue when editing

## Testing
- `npm run build`
- `npm run lint` *(fails: Parsing error: 'originalKeywordKind' has been deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_6877e8f104288325afb8a8009eb457bc