### PR TITLE
Fix open step for dev examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ The `BBoxAnnotator` Component takes the following props in order to control it's
  * `onChange: (entries: { left: number; top: number; width: number; height: number; label: string }[]) => void`: Callback containing list of annotated objects. Gets triggered when adding an annotation or removing one.
  * `labels?: string | string[]`: List of labels to annotate, if any are known in advance (only used with inputMethod `select`).
  * `borderWidth?: number`: Width of bounding box border in pixels.
- * `initialEntries?: { left: number; top: number; width: number; height: number; label: string }[]`: Load existing annotations so they can be edited.
+* `initialEntries?: { left: number; top: number; width: number; height: number; label: string }[]`: Load existing annotations so they can be edited.
 
-Boxes can be repositioned after creation by dragging them with the mouse.\n## Local examples\nRun `npm run examples` and open the served page to try interactive examples located in the `examples` folder.
+Boxes can be repositioned after creation by dragging them with the mouse.
+
+## Local examples
+Run `npm run examples` to start a dev server serving the content of the `examples` folder. Open the printed address in your browser, or set `OPEN_BROWSER=true` to automatically launch it when supported.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,9 @@ Run the following command from the repository root to start a development server
 npm run examples
 ```
 
-This will launch a Vite web server and open a page showing two examples:
+This launches a Vite web server. Open the printed address in your browser to
+see two examples. Set `OPEN_BROWSER=true` when running the command if you want
+the page to open automatically (requires a compatible `open` utility):
 
 1. A selector based example where labels are chosen from a list.
 2. A text input based example for free form labels.

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     },
   },
   server: {
-    open: true,
+    // Only open the browser if explicitly requested to avoid failures when
+    // utilities like `xdg-open` are unavailable.
+    open: process.env.OPEN_BROWSER === 'true',
   },
 });


### PR DESCRIPTION
## Summary
- disable automatic browser open unless `OPEN_BROWSER` is set
- document manual example startup and optional `OPEN_BROWSER` env var

## Testing
- `npm run lint` *(fails: Parsing error - originalKeywordKind has been deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_6877e9f298b08325a974b34b33dc4ea8