### PR TITLE
Fix editing reset on delete

### DIFF
--- a/src/BBoxAnnotator/index.tsx
+++ b/src/BBoxAnnotator/index.tsx
@@ -433,6 +433,10 @@ const BBoxAnnotator = React.forwardRef<any, Props>(
                                     }}
                                     onClick={() => {
                                         setEntries(entries.filter((e) => e.id !== entry.id));
+                                        if (editingId === entry.id) {
+                                            setEditingId(null);
+                                            setStatus('free');
+                                        }
                                     }}
                                 >
                                     <div
@@ -554,4 +558,5 @@ const BBoxAnnotator = React.forwardRef<any, Props>(
         );
     },
 );
+BBoxAnnotator.displayName = 'BBoxAnnotator';
 export default BBoxAnnotator;


### PR DESCRIPTION
## Summary
- ensure deleting an entry also clears editing state
- add display name for the BBoxAnnotator component

## Testing
- `npm run lint` *(fails: prettier/prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877edaff3488325a2c660daf9d5fbc7